### PR TITLE
Preserve location hash

### DIFF
--- a/set-query-string.js
+++ b/set-query-string.js
@@ -43,6 +43,11 @@ if (!replaceState) {
       newString = '?' + newString
     }
 
-    historyFunc.call(window.history, options.state || window.history.state, '', window.location.pathname + (newString || ''))
+    historyFunc.call(
+      window.history, 
+      options.state || window.history.state, 
+      '', 
+      window.location.pathname + (newString || '') + window.location.hash
+    )
   }
 }


### PR DESCRIPTION
Fixes #6. 

If there is no hash in the URL, `window.location.hash` resolves to empty string.